### PR TITLE
DEV-4688: Add missing PubSub properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ These types of resources are supported:
 * [Subscription](https://www.terraform.io/docs/providers/google/r/pubsub_subscription.html)
 * [Topic IAM member](https://www.terraform.io/docs/providers/google/r/pubsub_topic_iam.html)
 
+## Note
+
+If you wish to use `retentionDuration`, `retainAcked` or `expirationTtl` you need the `google` provider `~> 2.20`
+
 ## Usage
 
 e.g.: **pubsub.tf**

--- a/modules/subscription/main.tf
+++ b/modules/subscription/main.tf
@@ -10,6 +10,11 @@ resource "google_pubsub_subscription" "pubsub_subscription_pull" {
 
   name                 = "${lookup(var.pullSubscriptions[count.index], "name")}"
   ack_deadline_seconds = "${lookup(var.pullSubscriptions[count.index], "deadline", 10)}"
+  message_retention_duration = "${lookup(var.pullSubscriptions[count.index], "retentionDuration", "604800")}s"
+  retain_acked_messages = "${lookup(var.pullSubscriptions[count.index], "retainAcked", false)}"
+  expiration_policy = {
+    ttl = "${lookup(var.pullSubscriptions[count.index], "expirationPolicy", "2678400")}s"
+  }
 }
 
 resource "google_pubsub_subscription" "pubsub_subscription_push" {
@@ -19,6 +24,11 @@ resource "google_pubsub_subscription" "pubsub_subscription_push" {
 
   name                 = "${lookup(var.pushSubscriptions[count.index], "name")}"
   ack_deadline_seconds = "${lookup(var.pushSubscriptions[count.index], "deadline", 10)}"
+  message_retention_duration = "${lookup(var.pushSubscriptions[count.index], "retentionDuration", "604800")}s"
+  retain_acked_messages = "${lookup(var.pushSubscriptions[count.index], "retainAcked", false)}"
+  expiration_policy = {
+    ttl = "${lookup(var.pushSubscriptions[count.index], "expirationPolicy", "2678400")}s"
+  }
 
   push_config {
     push_endpoint = "${lookup(var.pushSubscriptions[count.index], "url")}"

--- a/modules/subscription/variables.tf
+++ b/modules/subscription/variables.tf
@@ -14,6 +14,9 @@ variable "pullSubscriptions" {
     Attributes:
      - name
      - deadline (optional) (default: 10)
+     - retentionDuration (optional) (default: 604800)
+     - retainAcked (optional) (default: false)
+     - expirationTtl (optional) (default: 2678400)
 EOF
 }
 
@@ -26,5 +29,8 @@ variable "pushSubscriptions" {
      - name
      - url
      - deadline (optional) (default: 10)
+     - retentionDuration (optional) (default: 604800)
+     - retainAcked (optional) (default: false)
+     - expirationTtl (optional) (default: 2678400)
 EOF
 }

--- a/variables.tf
+++ b/variables.tf
@@ -28,12 +28,18 @@ variable "definition" {
         The list of PULL subscriptions should be defined by those attributes:
           - name
           - deadline (optional) (default: 10)
+          - retentionDuration (optional) (default: 604800)
+          - retainAcked (optional) (default: false)
+          - expirationTtl (optional) (default: 2678400})
 
       - push [list]
         The list of PUSH subscriptions should be defined by those attributes:
           - name
           - url
           - deadline (optional) (default: 10)
+          - retentionDuration (optional) (default: 604800)
+          - retainAcked (optional) (default: false)
+          - expirationTtl (optional) (default: 2678400)
   EOF
 }
 


### PR DESCRIPTION
This adds the properties:
* `retentionDuration` -> [message_retention_duration](https://www.terraform.io/docs/providers/google/r/pubsub_subscription.html#message_retention_duration)
* `retainAcked` -> [retain_acked_messages](https://www.terraform.io/docs/providers/google/r/pubsub_subscription.html#retain_acked_messages)
* `expirationTtl` -> [expiration_policy.ttl](https://www.terraform.io/docs/providers/google/r/pubsub_subscription.html#ttl)